### PR TITLE
Refactor POST endpoint to use TodoItemDTO

### DIFF
--- a/TodoApi/DTOs/TodoItemDTO.cs
+++ b/TodoApi/DTOs/TodoItemDTO.cs
@@ -1,0 +1,18 @@
+// Reminder: DTO stands for data transfer object
+using TodoApi.Models;
+
+public class TodoItemDTO
+{
+    private int _id;
+    public int Id
+    {
+        get { return _id; }
+    }
+
+    public string? Name { get; set; }
+    public bool IsComplete { get; set; }
+
+    public TodoItemDTO() { }
+    public TodoItemDTO(Todo todoItem) =>
+    (_id, Name, IsComplete) = (todoItem.Id, todoItem.Name, todoItem.IsComplete);
+}

--- a/TodoApi/Program.cs
+++ b/TodoApi/Program.cs
@@ -8,7 +8,7 @@ builder.Services.AddDatabaseDeveloperPageExceptionFilter();
 
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddOpenApiDocument(config =>
-{v
+{
     config.DocumentName = "TodoAPI";
     config.Title = "TodoAPI v1";
     config.Version = "v1";
@@ -40,9 +40,17 @@ app.MapGet("/todoitems/{id}", async (int id, TodoDb db) =>
             ? Results.Ok(todo)
             : Results.NotFound());
 
-app.MapPost("/todoitems", async (Todo todo, TodoDb db) =>
+app.MapPost("/todoitems", async (TodoItemDTO todo, TodoDb db) =>
 {
-    db.Todos.Add(todo);
+    // TODO: when back in class on Tuesday - lets work on the ID property
+    var todoToAdd = new Todo
+    {
+        Name = todo.Name,
+        IsComplete = todo.IsComplete,
+        Id = todo.Id,
+    };
+
+    db.Todos.Add(todoToAdd);
     await db.SaveChangesAsync();
 
     return Results.Created($"/todoitems/{todo.Id}", todo);


### PR DESCRIPTION
Modifies the /todoitems POST endpoint to accept a TodoItemDTO instead of the Todo entity directly. This change improves separation of concerns and data transfer security.

Adds a TODO reminder for future ID property work scheduled for Tuesday's class.